### PR TITLE
Enlarge logos without resizing navbar

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -40,9 +40,11 @@ nav {
 /* BOTH logos: fill nav bar height */
 .logo-icon,
 .title-image {
-  height: 100%;           /* Makes both logos exactly as tall as nav bar */
+  height: 100%;           /* Keep base height equal to nav bar */
   width: auto;
   display: block;
+  transform: scale(1.2);  /* Enlarge logos while nav bar stays fixed */
+  transform-origin: center;
 }
 
 /* Nav links */


### PR DESCRIPTION
## Summary
- enlarge the two logos inside the navbar with a CSS transform while keeping the navbar height fixed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68431043a9cc8333b010328a3b3e5912