### PR TITLE
Adjust service page styles

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -183,6 +183,10 @@ header::before {
     text-align: center;
 }
 
+#services h2 {
+    color: #ffd600;
+}
+
 .service-list {
     display: flex;
     flex-wrap: wrap;
@@ -328,7 +332,7 @@ footer {
     border-spacing: 0;
     box-shadow: 0 4px 24px rgba(16,25,64,0.28);
     overflow: hidden;
-    min-width: 720px;
+    width: 100%;
     margin: 0 auto;
     font-family: 'Montserrat', Arial, sans-serif;
 }


### PR DESCRIPTION
## Summary
- make the services table responsive
- color the "Our Services" heading yellow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843235adb1c83339013e11a9bd38b65