### PR TITLE
Fix nav anchor overlap

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -152,6 +152,7 @@ header::before {
 #about {
     padding: 40px 20px;
     text-align: center;
+    scroll-margin-top: 80px; /* Prevent content from hiding behind navbar */
 }
 
 /* Gallery */
@@ -181,6 +182,7 @@ header::before {
     padding: 40px 20px;
     background-color: white;
     text-align: center;
+    scroll-margin-top: 80px; /* Prevent content from hiding behind navbar */
 }
 
 #services h2 {
@@ -217,6 +219,7 @@ header::before {
     padding: 40px 20px;
     background-color: #e8f0fe;
     text-align: center;
+    scroll-margin-top: 80px; /* Prevent content from hiding behind navbar */
 }
 
 form {


### PR DESCRIPTION
## Summary
- ensure About Us, Services, and Contact sections scroll into view below navbar

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_b_68432484e2f483338ce00b2e3728b88e