### PR TITLE
Replace hero heading with logo image

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -124,8 +124,11 @@ header::before {
     max-width: 500px;
 }
 
-.hero-content h1 {
-    font-size: 48px;
+
+/* Hero logo replaces heading text */
+.hero-logo {
+    height: 48px;
+    width: auto;
     margin-bottom: 10px;
 }
 

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <!-- Hero Section -->
   <header>
     <div class="hero-content">
-      <h1>RideShine</h1>
+      <img src="Images/newlogo.png" alt="RideShine Logo" class="hero-logo" />
       <p>We bring the shine to you!</p>
       <button onclick="scrollToContact()">Book a Wash</button>
     </div>


### PR DESCRIPTION
## Summary
- swap the "RideShine" header text for a logo image on the home page
- style the hero logo so it matches the previous heading space

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684327f59bb08333aa66050caf39e49c