### PR TITLE
Adjust hero logo spacing

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -129,7 +129,8 @@ header::before {
 .hero-logo {
     height: 260px; /* make hero logo larger for the home page */
     width: auto;
-    margin-bottom: 15px; /* keep text directly underneath */
+    /* Position logo half an inch above the tagline */
+    margin-bottom: 0.5in;
 }
 
 .hero-content p {


### PR DESCRIPTION
## Summary
- make newlogo image sit half an inch above the tagline on the hero section

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_b_68432fda0a1c833396ab8cd93d9d0ffb