### PR TITLE
Fix hero logo spacing

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -129,6 +129,7 @@ header::before {
 .hero-logo {
     height: 260px; /* make hero logo larger for the home page */
     width: auto;
+    display: block; /* allow vertical margins to take effect */
     /* Position logo half an inch above the tagline */
     margin-bottom: 0.5in;
 }


### PR DESCRIPTION
## Summary
- allow hero logo margins to push the tagline down

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684333b0a8cc8333b89e46cbe7c7d2d2