### PR TITLE
Improve About Us layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -154,14 +154,84 @@ header::before {
    About Section
 ======================= */
 #about {
-    padding: 40px 20px;
-    text-align: center;
+    background-color: #101940;
+    padding: 60px 20px;
     scroll-margin-top: 80px;
+    text-align: center;
+}
+
+.about-card {
+    background-color: #fff;
+    border-radius: 12px;
     max-width: 8.5in;
     margin: 0 auto;
+    padding: 40px 30px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
+
+.about-logo {
+    width: 180px;
+    height: auto;
+    display: block;
+    margin: 0 auto 10px auto;
+}
+
 #about h2 {
     color: #101940;
+    margin-top: 0;
+}
+
+.special-list {
+    list-style: none;
+    padding: 0;
+    margin: 20px auto;
+    max-width: 600px;
+    text-align: left;
+}
+
+.special-list li {
+    position: relative;
+    padding-left: 28px;
+    margin-bottom: 10px;
+}
+
+.special-list li::before {
+    content: '\2714';
+    position: absolute;
+    left: 0;
+    color: #ffd600;
+    font-weight: bold;
+}
+
+.tagline-badge {
+    background-color: #ffd600;
+    color: #101940;
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: bold;
+    margin: 20px 0;
+}
+
+.mission-vision {
+    display: flex;
+    gap: 20px;
+    margin-top: 30px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.mission-vision .mv-card {
+    background-color: #e8f0ff;
+    border-radius: 10px;
+    padding: 20px;
+    flex: 1 1 260px;
+    max-width: 400px;
+}
+
+.mission-vision .mv-card h3 {
+    color: #101940;
+    margin-top: 0;
 }
 
 /* =======================
@@ -409,5 +479,9 @@ footer {
     }
     .hero-logo {
         height: 120px;
+    }
+
+    .mission-vision {
+        flex-direction: column;
     }
 }

--- a/index.html
+++ b/index.html
@@ -35,21 +35,29 @@
 
   <!-- About Us Section -->
   <section id="about">
-    <h2>About Us</h2>
-    <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
-    <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
-    <p><strong>What Makes RideShine Special?</strong></p>
-    <ul>
-      <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
-      <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
-      <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
-    </ul>
-    <p>As three local friends, we’re passionate about growing our business and building strong relationships with our customers. RideShine is where we see ourselves growing and progressing together, always striving to exceed your expectations.</p>
-    <p>We bring the shine to you!</p>
-    <p><strong>Mission Statement</strong></p>
-    <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
-    <p><strong>Vision Statement</strong></p>
-    <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+    <div class="about-card">
+      <img src="Images/newlogo.png" alt="RideShine Logo" class="about-logo" />
+      <h2>About Us</h2>
+      <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
+      <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
+      <h3>What Makes RideShine Special?</h3>
+      <ul class="special-list">
+        <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
+        <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
+        <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
+      </ul>
+      <p class="tagline-badge">We bring the shine to you!</p>
+      <div class="mission-vision">
+        <div class="mv-card">
+          <h3>Mission</h3>
+          <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
+        </div>
+        <div class="mv-card">
+          <h3>Vision</h3>
+          <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+        </div>
+      </div>
+    </div>
   </section>
 
   <!-- Gallery Section -->


### PR DESCRIPTION
## Summary
- redesign About Us section with card layout
- highlight tagline and mission/vision panels
- adjust responsive styles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684721acc1b883338e029db62545454f