### PR TITLE
Resize about logo to match navbar

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -170,8 +170,8 @@ header::before {
 }
 
 .about-logo {
-    width: 180px;
-    height: auto;
+    height: 72px;
+    width: auto;
     display: block;
     margin: 0 auto 10px auto;
 }


### PR DESCRIPTION
## Summary
- scale down the about section logo to the same height as the navbar logo

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68472365373c833398801e0e1e3ba947