### PR TITLE
Improve spacing in About section

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -181,6 +181,11 @@ header::before {
     margin-top: 0;
 }
 
+/* Spacing above the "What Makes RideShine Special?" heading */
+#about .about-subheading {
+    margin-top: 30px;
+}
+
 .special-list {
     list-style: none;
     padding: 0;

--- a/index.html
+++ b/index.html
@@ -40,7 +40,8 @@
       <h2>About Us</h2>
       <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
       <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
-      <h3>What Makes RideShine Special?</h3>
+      <br />
+      <h3 class="about-subheading">What Makes RideShine Special?</h3>
       <ul class="special-list">
         <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
         <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>


### PR DESCRIPTION
## Summary
- add explicit line break before "What Makes RideShine Special?" heading
- style new heading with extra margin for spacing

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6847258f8b9483339eda8af0dfdb6965