### PR TITLE
Sync about card and service table widths

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -164,7 +164,8 @@ header::before {
     background-color: #101940; /* navy background */
     border: 3px solid #ffd600; /* gold outline */
     border-radius: 18px;
-    max-width: 8.5in;
+    max-width: 980px;
+    width: 100%;
     margin: 0 auto;
     padding: 40px 30px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- match `.about-card` width to the service table so they share the same max width

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68473c3f93c08333a35b27a9830cb434