### PR TITLE
Update about tagline position

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,8 +48,7 @@
         <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
         <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
       </ul>
-      <p class="tagline-badge">We bring the shine to you!</p>
-          <h3>Mission</h3>
+            <h3>Mission</h3>
           <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
         </div>
         <div class="mv-card">
@@ -57,8 +56,9 @@
           <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
           <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
         </div>
+        </div>
+        <p class="tagline-badge">We bring the shine to you!</p>
       </div>
-    </div>
   </section>
 
   <!-- Gallery Section -->


### PR DESCRIPTION
## Summary
- move tagline badge below mission/vision cards on the About page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68474209c19483338e838184ffb2148e