### PR TITLE
Adjust vision layout and logo size

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -238,9 +238,19 @@ header::before {
 }
 .mission-vision .vision-logo {
     display: block;
-    width: 80px;
+    width: 120px;
     height: auto;
     margin: 0 auto 10px;
+}
+
+.vision-card {
+    display: flex;
+    flex-direction: column;
+    text-align: left;
+}
+.vision-card p {
+    margin-top: auto;
+    text-align: left;
 }
 
 /* =======================

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
             <h3>Mission</h3>
           <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
         </div>
-        <div class="mv-card">
+        <div class="mv-card vision-card">
           <h3>Vision</h3>
           <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
           <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>


### PR DESCRIPTION
## Summary
- align vision text with the mission card
- keep logo inside vision card but make it larger

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_684743d701d88333bdc3be56c497a625