### PR TITLE
Adjust about section layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -178,9 +178,10 @@ header::before {
     margin-top: 0;
 }
 
-/* Spacing above the "What Makes RideShine Special?" heading */
+/* Spacing around the "What Makes RideShine Special?" heading */
 #about .about-subheading {
     margin-top: 30px;
+    margin-bottom: 10px;
 }
 
 .special-list {
@@ -221,6 +222,7 @@ header::before {
     margin-top: 30px;
     justify-content: center;
     flex-wrap: wrap;
+    align-items: stretch;
 }
 
 .vision-group {
@@ -236,11 +238,17 @@ header::before {
     flex: 1 1 260px;
     max-width: 400px;
     color: #101940;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .mission-vision .mv-card h3 {
     color: #101940;
     margin-top: 0;
+}
+.mission-vision .mv-card p {
+    margin-top: auto;
 }
 .mission-vision .vision-logo {
     display: block;

--- a/index.html
+++ b/index.html
@@ -40,12 +40,12 @@
       <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
       <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
       <br />
+      <h3 class="about-subheading">What Makes RideShine Special?</h3>
       <ul class="special-list">
         <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
         <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
         <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
       </ul>
-      <h3 class="about-subheading">What Makes RideShine Special?</h3>
       <div class="mission-vision">
         <div class="mv-card">
           <h3>Mission</h3>


### PR DESCRIPTION
## Summary
- move the "What Makes RideShine Special?" heading above the key points list
- give heading bottom margin for spacing
- ensure Mission and Vision cards stretch to the same height

## Testing
- `git diff --name-status --cached`


------
https://chatgpt.com/codex/tasks/task_b_68474933a7348333abe38ac092bad2ad