### PR TITLE
Fix vision card alignment

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -260,11 +260,11 @@ header::before {
 .vision-card {
     display: flex;
     flex-direction: column;
-    text-align: left;
+    text-align: center;
 }
 .vision-card p {
     margin-top: auto;
-    text-align: left;
+    text-align: center;
 }
 
 /* =======================


### PR DESCRIPTION
## Summary
- center text inside Vision box so it matches Mission box

## Testing
- `npx --yes serve . > /tmp/serve.log 2>&1 &`


------
https://chatgpt.com/codex/tasks/task_b_68475d40d9408333bab7b5bb1fb31dfa