### PR TITLE
Adjust mission/vision layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -216,13 +216,26 @@ header::before {
     margin: 20px 0;
 }
 
+
 .mission-vision {
     display: flex;
     gap: 20px;
-    margin-top: 30px;
+    margin: 30px 0 20px;
     justify-content: center;
     flex-wrap: wrap;
     align-items: stretch;
+}
+
+.vision-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1 1 260px;
+    max-width: 400px;
+}
+
+.vision-wrapper .mv-card {
+    width: 100%;
 }
 
 
@@ -511,5 +524,9 @@ footer {
 
     .mission-vision {
         flex-direction: column;
+    }
+
+    .vision-wrapper {
+        max-width: none;
     }
 }

--- a/index.html
+++ b/index.html
@@ -46,15 +46,17 @@
         <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
         <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
       </ul>
-        <div class="mission-vision">
+      <div class="mission-vision">
         <div class="mv-card">
           <h3>Mission</h3>
           <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
         </div>
-        <div class="mv-card vision-card">
+        <div class="vision-wrapper">
           <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
-          <h3>Vision</h3>
-          <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+          <div class="mv-card vision-card">
+            <h3>Vision</h3>
+            <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+          </div>
         </div>
       </div>
       <p class="tagline-badge">We bring the shine to you!</p>


### PR DESCRIPTION
## Summary
- move the logo out of the Vision card
- wrap the Vision card with a container to hold the logo
- align Mission and Vision boxes and add spacing
- tweak responsive styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68476140844083339f7b37f08e57b472