### PR TITLE
Implement mission/vision layout changes

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -213,7 +213,14 @@ header::before {
     padding: 8px 16px;
     border-radius: 20px;
     font-weight: bold;
-    margin: 20px 0;
+    margin: 20px auto;
+    text-align: center;
+}
+
+.tagline-button {
+    border: none;
+    cursor: pointer;
+    display: block;
 }
 
 
@@ -227,6 +234,14 @@ header::before {
 }
 
 .vision-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1 1 260px;
+    max-width: 400px;
+}
+
+.mission-wrapper {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -527,6 +542,9 @@ footer {
     }
 
     .vision-wrapper {
+        max-width: none;
+    }
+    .mission-wrapper {
         max-width: none;
     }
 }

--- a/index.html
+++ b/index.html
@@ -40,28 +40,30 @@
       <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
       <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
       <br />
-      <h3 class="about-subheading">What Makes RideShine Special?</h3>
-      <ul class="special-list">
-        <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
-        <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
-        <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
-      </ul>
-      <div class="mission-vision">
-        <div class="mv-card">
-          <h3>Mission</h3>
-          <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
-        </div>
-        <div class="vision-wrapper">
-          <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
-          <div class="mv-card vision-card">
-            <h3>Vision</h3>
-            <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+        <div class="mission-vision">
+          <div class="mission-wrapper">
+            <h3 class="about-subheading">What Makes RideShine Special?</h3>
+            <ul class="special-list">
+              <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
+              <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
+              <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
+            </ul>
+            <div class="mv-card">
+              <h3>Mission</h3>
+              <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
+            </div>
+          </div>
+          <div class="vision-wrapper">
+            <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
+            <div class="mv-card vision-card">
+              <h3>Vision</h3>
+              <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
+            </div>
           </div>
         </div>
-      </div>
-      <p class="tagline-badge">We bring the shine to you!</p>
-      </div>
-  </section>
+        <button type="button" class="tagline-badge tagline-button">We bring the shine to you!</button>
+        </div>
+    </section>
 
   <!-- Gallery Section -->
   <section id="gallery">


### PR DESCRIPTION
## Summary
- reorganize Mission and Vision content
- move feature list above the mission card
- style new mission wrapper and tagline button
- keep responsive design for mission and vision sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68476306f4608333a7d96358b0bb7e56