### PR TITLE
Fix Mission/Vision box layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -258,12 +258,11 @@ header::before {
     background-color: #e8f0ff;
     border-radius: 10px;
     padding: 20px;
-    flex: 1 1 260px;
-    max-width: 400px;
+    width: 100%;
+    flex-grow: 1;
     color: #101940;
     display: flex;
     flex-direction: column;
-    height: 100%;
 }
 
 .mission-vision .mv-card h3 {

--- a/index.html
+++ b/index.html
@@ -40,14 +40,14 @@
       <p>RideShine is Windsor, Ontario’s trusted mobile car wash and detailing service, proudly run by three friends who turned their dream of owning a business into reality.</p>
       <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
       <br />
+        <h3 class="about-subheading">What Makes RideShine Special?</h3>
+        <ul class="special-list">
+          <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
+          <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
+          <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
+        </ul>
         <div class="mission-vision">
           <div class="mission-wrapper">
-            <h3 class="about-subheading">What Makes RideShine Special?</h3>
-            <ul class="special-list">
-              <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
-              <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
-              <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
-            </ul>
             <div class="mv-card">
               <h3>Mission</h3>
               <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>


### PR DESCRIPTION
## Summary
- move 'What Makes RideShine Special' list outside the mission card
- keep mission and vision cards the same height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6847955cb5008333b13ef7e9fc5a73e7