### PR TITLE
Adjust mission/vision layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -225,37 +225,20 @@ header::before {
 
 
 .mission-vision {
-    display: flex;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
     gap: 20px;
     margin: 30px 0 20px;
-    justify-content: center;
-    flex-wrap: wrap;
-    align-items: stretch;
+    justify-items: stretch;
+    align-items: start;
 }
 
-.vision-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    flex: 1 1 260px;
-    max-width: 400px;
-}
-
-.mission-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    flex: 1 1 260px;
-    max-width: 400px;
-}
-
-.mission-wrapper .mv-card {
+.special-section {
+    align-self: start;
     width: 100%;
 }
 
-.vision-wrapper .mv-card {
-    width: 100%;
-}
 
 
 .mission-vision .mv-card {
@@ -277,11 +260,18 @@ header::before {
 .mission-vision .mv-card p {
     margin-top: auto;
 }
+.logo-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .vision-logo {
     display: block;
-    width: 160px;
+    width: 100%;
+    max-width: 300px;
     height: auto;
-    margin: 0 auto 10px;
+    margin: 0 auto;
 }
 
 .vision-card {
@@ -542,13 +532,11 @@ footer {
     }
 
     .mission-vision {
+        display: flex;
         flex-direction: column;
+        align-items: center;
     }
-
-    .vision-wrapper {
-        max-width: none;
-    }
-    .mission-wrapper {
-        max-width: none;
+    .logo-container, .special-section, .mission-card, .vision-card {
+        width: 100%;
     }
 }

--- a/index.html
+++ b/index.html
@@ -41,24 +41,24 @@
       <p>We started RideShine with a shared passion for cars and a commitment to bringing something new to our community. Our journey began with the simple idea that professional car care should be convenient and always delivered with attention to detail. Today, we’re excited to help drivers in Windsor and the surrounding area keep their vehicles spotless—right at their doorsteps.</p>
       <br />
         <div class="mission-vision">
-          <div class="mission-wrapper">
+          <div class="special-section">
             <h3 class="about-subheading">What Makes RideShine Special?</h3>
             <ul class="special-list">
               <li><strong>Fully Mobile:</strong> We bring our car wash and detailing services straight to your home or workplace, saving you time and hassle.</li>
               <li><strong>Attention to Detail:</strong> Every car is treated like our own. We take pride in delivering spotless, showroom-quality results—every time.</li>
               <li><strong>Fast &amp; Reliable Service:</strong> Your time is valuable, and we’re committed to providing efficient, on-time service you can count on.</li>
             </ul>
-            <div class="mv-card">
-              <h3>Mission</h3>
-              <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
-            </div>
           </div>
-          <div class="vision-wrapper">
+          <div class="logo-container">
             <img src="Images/logo.png" alt="RideShine Logo" class="vision-logo" />
-            <div class="mv-card vision-card">
-              <h3>Vision</h3>
-              <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
-            </div>
+          </div>
+          <div class="mv-card mission-card">
+            <h3>Mission</h3>
+            <p>Our mission is to deliver convenient, professional car wash and detailing services to Windsor and the surrounding area—right at your doorstep. We are dedicated to exceptional customer care, outstanding results, and making car care simple for everyone.</p>
+          </div>
+          <div class="mv-card vision-card">
+            <h3>Vision</h3>
+            <p>Our vision is to become the leading mobile car care provider for Windsor and surrounding communities, known for reliability, quality, and a personal touch. We aim to grow together as friends and entrepreneurs, setting new standards for convenience and excellence in the car detailing industry.</p>
           </div>
         </div>
         <button type="button" class="tagline-badge tagline-button">We bring the shine to you!</button>


### PR DESCRIPTION
## Summary
- use grid layout for mission/vision content
- place large logo next to bullet list
- ensure mission and vision cards sit side by side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68479dedb93483339c6c3a5090b275e8