### PR TITLE
Fix Mission & Vision layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -228,13 +228,17 @@ header::before {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto auto;
+    grid-template-areas:
+        "special logo"
+        "mission vision";
     gap: 20px;
     margin: 30px 0 20px;
     justify-items: stretch;
-    align-items: start;
+    align-items: stretch;
 }
 
 .special-section {
+    grid-area: special;
     align-self: start;
     width: 100%;
 }
@@ -251,6 +255,7 @@ header::before {
     color: #101940;
     display: flex;
     flex-direction: column;
+    height: 100%;
 }
 
 .mission-vision .mv-card h3 {
@@ -261,9 +266,18 @@ header::before {
     margin-top: auto;
 }
 .logo-container {
+    grid-area: logo;
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.mission-card {
+    grid-area: mission;
+}
+
+.vision-card {
+    grid-area: vision;
 }
 
 .vision-logo {


### PR DESCRIPTION
## Summary
- use CSS grid areas to place mission and vision cards
- keep logo and bullet list unchanged
- make mission and vision cards stretch equally
- maintain responsive stacking on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6847a01c74fc8333a56fad7cd7e31f20