### PR TITLE
Fix mission layout spacing

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -221,6 +221,7 @@ header::before {
     border: none;
     cursor: pointer;
     display: block;
+    margin: 20px auto 0; /* ensure clear space below the boxes */
 }
 
 
@@ -261,9 +262,10 @@ header::before {
 .mission-vision .mv-card h3 {
     color: #101940;
     margin-top: 0;
+    margin-bottom: 10px; /* keep heading close to text */
 }
 .mission-vision .mv-card p {
-    margin-top: auto;
+    margin: 0; /* remove large gap between heading and text */
 }
 .logo-container {
     grid-area: logo;


### PR DESCRIPTION
## Summary
- adjust tagline spacing so button sits below the cards
- tighten spacing between Mission/Vision headers and their text

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6847a56fef788333bc51cd69ae550af1