### PR TITLE
Fix tall mission/vision boxes

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -251,12 +251,9 @@ header::before {
     border-radius: 10px;
     padding: 20px;
     width: 100%;
-    min-height: 260px;
-    flex-grow: 1;
     color: #101940;
     display: flex;
     flex-direction: column;
-    height: 100%;
 }
 
 .mission-vision .mv-card h3 {


### PR DESCRIPTION
## Summary
- remove min-height and height from mission & vision boxes so they size to their content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6847a7b2a4d08333be3492bc695c4376