### PR TITLE
Add rule to hide hamburger on desktop

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -80,6 +80,11 @@ nav {
     outline: none;
 }
 
+/* Hide hamburger button on larger screens */
+.nav-toggle {
+    display: none;
+}
+
 /* =======================
    Hero Section
 ======================= */


### PR DESCRIPTION
## Summary
- hide the hamburger nav button on desktop while keeping the mobile menu styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6848290e70448333bb5925bab0aa43cd