### PR TITLE
Add responsive viewport and mobile style fixes

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -530,7 +530,7 @@ footer {
 /* =======================
    Responsive (Mobile)
 ======================= */
-@media (max-width: 900px) {
+@media (max-width: 768px) {
     .about-special-row, .about-mv-row {
         flex-direction: column;
         gap: 24px;
@@ -562,10 +562,11 @@ footer {
         font-size: 1.2em;
     }
     .hero-content {
-        right: 3%;
-        left: 3%;
-        max-width: 97vw;
+        margin: 0 auto 80px auto;
+        max-width: 94vw;
         gap: 10px;
+        text-align: center;
+        align-items: center;
     }
     .hero-logo {
         height: 120px;
@@ -596,6 +597,8 @@ footer {
     }
     .nav-links {
         gap: 25px;
+        flex-wrap: wrap;
+        justify-content: center;
     }
     .nav-links li a {
         font-size: 18px;

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>RideShine Mobile Car Wash</title>
   <link rel="stylesheet" href="Style.css" />
   <link href="https://fonts.googleapis.com/css?family=Montserrat:600,400&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- enable proper responsive scaling with a viewport meta tag
- tweak mobile layout breakpoints and hero section styles
- allow navigation links to wrap on narrow screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684845c5cb0483338aeeef5edd65e3da