### PR TITLE
Ensure hamburger menu only on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -647,3 +647,10 @@ footer {
     }
 
 }
+
+@media (min-width: 769px) {
+    /* Ensure mobile menu stays hidden on larger screens */
+    .mobile-menu {
+        display: none !important;
+    }
+}


### PR DESCRIPTION
## Summary
- hide `mobile-menu` when viewport is larger than 768px to keep desktop layout clean

## Testing
- `npm test` *(fails: no `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68484ba56d708333a8dbb239a7d971c5