### PR TITLE
Fix hero image scaling on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -595,12 +595,16 @@ footer {
     /* Ensure hero background and images scale nicely on mobile */
     header {
         background-size: contain;
+        background-position: top center;
+        background-repeat: no-repeat;
     }
     .hero-logo,
     .gallery-container img {
         width: 100%;
         height: auto;
         object-fit: contain;
+        object-position: top center;
+        display: block;
     }
 }
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- update mobile hero section styles so the background image and hero logo no longer crop

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68484fc400cc8333bfb774930823bd6a