### PR TITLE
Center content for mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -607,6 +607,19 @@ footer {
         display: block;
     }
 }
+@media (max-width: 768px) {
+    body {
+        margin: 0 auto;
+        max-width: 100%;
+        padding: 0 16px;
+    }
+    img,
+    .about-card,
+    section {
+        display: block;
+        margin: 0 auto;
+    }
+}
 @media (max-width: 600px) {
     #service-table th,
     #service-table td {


### PR DESCRIPTION
## Summary
- add mobile-only CSS to center page sections and images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684852b184ec8333810663a9a7ef5107