### PR TITLE
Update mobile hero layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -682,3 +682,43 @@ footer {
         display: none !important;
     }
 }
+@media (max-width: 768px) {
+  header {
+    background: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    height: auto;
+  }
+  header::before {
+    display: none;
+  }
+  .hero-content {
+    margin: 0;
+    max-width: 100%;
+    gap: 1rem;
+    text-align: center;
+    align-items: center;
+  }
+  .hero-logo {
+    margin-bottom: 1rem;
+    max-width: 180px;
+    height: auto;
+  }
+  .hero-content p {
+    font-size: 1.25rem;
+    color: #ffffff;
+    margin-bottom: 1rem;
+  }
+  .hero-content button {
+    background-color: #FFD700;
+    color: #000;
+    padding: 12px 24px;
+    font-weight: bold;
+    border-radius: 6px;
+    border: none;
+  }
+}
+


### PR DESCRIPTION
## Summary
- adjust hero section layout on small screens
- stack the logo, tagline, and button vertically
- remove gray overlay under the hero for phones

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6848552793b08333bf13af4920a44ecb