### PR TITLE
Center about section on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -722,3 +722,13 @@ footer {
   }
 }
 
+@media (max-width: 768px) {
+  .about-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+  }
+}
+

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   </header>
 
   <!-- About Us Section -->
- <section id="about">
+ <section id="about" class="about-section">
   <div class="about-card about-stacked">
     <!-- 1. About Us Title -->
     <h2 class="about-center-title">About Us</h2>


### PR DESCRIPTION
## Summary
- mark about section with a new class
- center `.about-section` when the viewport width is 768px or below

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6848593dec148333b2093bfef9829741