### PR TITLE
Center about-section elements on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -730,5 +730,18 @@ footer {
     justify-content: center;
     padding: 1.5rem 1rem;
   }
+  .about-section h2,
+  .about-section h3,
+  .about-section p {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .about-section img,
+  .about-section .tagline-badge,
+  .about-section .badge {
+    display: block;
+    margin: 1rem auto;
+  }
 }
 


### PR DESCRIPTION
## Summary
- center text, icons, and badges inside the about section on small screens

## Testing
- `npx prettier -c Style.css`

------
https://chatgpt.com/codex/tasks/task_b_68485bbdf6e08333aa4b0f269f0c0157