### PR TITLE
Fix mission and vision box spacing on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -750,7 +750,7 @@ footer {
   .mission-box,
   .vision-box {
     padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding-bottom: 0;
     margin-top: 0;
     margin-bottom: 0;
   }
@@ -763,11 +763,22 @@ footer {
   .mission-box > :last-child,
   .vision-box > :last-child {
     margin-bottom: 0;
+    padding-bottom: 0;
   }
 
   .mission-box > *:empty,
   .vision-box > *:empty {
     display: none;
     height: 0;
+  }
+
+  .mission-box > br,
+  .vision-box > br {
+    display: none;
+  }
+
+  .mission-box p:empty,
+  .vision-box p:empty {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- adjust mission and vision styles in mobile media query
- hide redundant empty or break elements

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_b_684863e8ff988333aeb3a57bedbac79d