### PR TITLE
Center about section on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -729,11 +729,14 @@ footer {
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    width: 100%;
+    max-width: 95%;
+    margin: 0 auto !important;
     padding: 1.5rem 1rem;
+    box-sizing: border-box;
+    text-align: center;
   }
-  .about-section h2,
-  .about-section h3,
-  .about-section p {
+  .about-section * {
     text-align: center;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
## Summary
- fix layout for `.about-section` on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68486f3f0c9483338a81b4566ea27a2a