### PR TITLE
Fix mobile centering of about section

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -785,3 +785,23 @@ footer {
     display: none;
   }
 }
+
+/* Override layout for mobile to ensure about section is centered */
+@media (max-width: 768px) {
+  .about-section {
+    all: unset;
+    width: 100%;
+    max-width: 95%;
+    margin: 0 auto !important;
+    padding: 1.5rem 1rem;
+    display: block;
+    text-align: center !important;
+    box-sizing: border-box;
+  }
+  .about-section * {
+    text-align: center !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary
- override inherited styles so `.about-section` is centered on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684870cbca3c83338a786384697f7ddf