### PR TITLE
Fix mobile layout for about section

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -805,3 +805,20 @@ footer {
     display: block;
   }
 }
+
+@media (max-width: 768px) {
+  .about-card.about-stacked,
+  .mission-box,
+  .vision-box {
+    width: 100%;
+    max-width: 95%;
+    margin: 0 auto;
+    box-sizing: border-box;
+    padding: 1rem;
+    text-align: center;
+  }
+  .about-card.about-stacked * {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure about section card and mission/vision boxes center and share width on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6848724a3b1483338d1502f40838b641