### PR TITLE
Add margin for mission box on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -822,3 +822,9 @@ footer {
     margin-right: auto;
   }
 }
+
+@media (max-width: 768px) {
+  .mission-box {
+    margin-bottom: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add CSS rule to provide a small gap under the Mission box on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6848768315148333a7b90bce590ccd30