### PR TITLE
Implement responsive mobile menu

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -85,11 +85,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const mobileMenu = document.getElementById("mobileMenu");
   if (hamburger && mobileMenu) {
     hamburger.addEventListener("click", () => {
-      mobileMenu.classList.toggle("active");
+      mobileMenu.classList.toggle("open");
     });
     mobileMenu.querySelectorAll("a").forEach(link => {
       link.addEventListener("click", () => {
-        mobileMenu.classList.remove("active");
+        mobileMenu.classList.remove("open");
       });
     });
   }

--- a/Style.css
+++ b/Style.css
@@ -112,8 +112,11 @@ nav {
     padding: 8px 0;
 }
 
-.mobile-menu.active {
-    display: flex;
+
+@media (max-width: 768px) {
+    .mobile-menu.open {
+        display: flex;
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- style `.mobile-menu` dropdown and show it with a new `.open` class
- toggle menu open/closed via Javascript

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684880e244208333ad64b26ae8e33cd1