### PR TITLE
Improve mobile menu styling

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -829,25 +829,34 @@ footer {
 
 @media (max-width: 768px) {
   .mobile-menu {
-    display: none;
-    flex-direction: column;
-    background-color: #0a0a23;
+    display: flex;
     position: absolute;
-    top: 60px;
-    right: 0;
-    width: 100%;
-    z-index: 1000;
-    padding: 1rem 0;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    background-color: #101940;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    flex-direction: column;
+    align-items: center;
+    padding: 10px 0;
+    overflow: hidden;
+    max-height: 0;
+    transition: max-height 0.3s ease-out;
+    list-style: none;
+    margin: 0;
   }
   .mobile-menu.open {
-    display: flex;
+    max-height: 500px;
   }
-  .mobile-menu a {
-    color: white;
-    padding: 1rem;
-    text-align: center;
-    text-decoration: none;
+  .mobile-menu li a {
     display: block;
+    width: 100%;
+    padding: 12px 0;
+    color: #fff;
+    text-decoration: none;
+    text-align: center;
   }
   .hamburger {
     background: none;


### PR DESCRIPTION
## Summary
- style the mobile dropdown menu with shadow and rounded corners
- center the menu under the navbar
- add slide-down animation and link spacing

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68499dcbe4908333acbf840ea72dae73