### PR TITLE
Fix mobile menu alignment

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -840,32 +840,32 @@ footer {
 @media (max-width: 768px) {
   .mobile-menu {
     display: none;
-    position: relative;
-    top: auto;
-    left: auto;
-    transform: none;
-    width: 95%;
-    margin: 0 auto;
+    position: absolute;
+    top: 72px; /* ensure menu appears below the navbar */
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90vw;
+    max-width: 90vw;
     background-color: #101940;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-    flex-direction: column;
-    justify-content: space-evenly;
-    align-items: center;
+    border-radius: 10px;
     padding: 20px 0;
+    flex-direction: column;
+    align-items: center;
+    z-index: 999;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
     list-style: none;
   }
   .mobile-menu.show {
     display: flex;
   }
+  .mobile-menu li {
+    margin: 14px 0;
+  }
   .mobile-menu li a {
-    display: block;
-    width: 100%;
-    padding: 16px 0;
-    color: #fff;
-    text-decoration: none;
-    text-align: center;
+    color: white;
     font-size: 20px;
+    text-decoration: none;
+    font-weight: 600;
   }
   .hamburger {
     background: none;


### PR DESCRIPTION
## Summary
- keep dropdown within the viewport on small screens
- center mobile menu under the hamburger button with padding and spacing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6849a74f196c8333acaba747cdc7ea2d