### PR TITLE
Fix hero image spacing on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -704,6 +704,9 @@ footer {
     position: relative;
     background: none;
     padding: 0;
+    display: block;
+    height: auto;
+    margin: 0;
   }
   header::before {
     display: none;
@@ -714,6 +717,7 @@ footer {
     height: auto;
     object-fit: cover;
     max-height: 100vh;
+    margin: 0;
   }
   .hero-content {
     position: static;


### PR DESCRIPTION
## Summary
- make header a block element and remove flex layout on mobile
- ensure hero image has no margin on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849aee2d3c08333bd1c616ce6463e16