### PR TITLE
Fix hero box width on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -650,10 +650,11 @@ footer {
         max-height: 100vh;
     }
     .hero-content {
-        margin: 0 auto;
+        margin: 0;
         padding: 20px 16px;
         gap: 12px;
-        width: fit-content;
+        width: 100%;
+        max-width: none;
     }
     .hero-logo {
         height: 120px;
@@ -729,8 +730,9 @@ footer {
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    margin: 0 auto;
-    width: fit-content;
+    margin: 0;
+    width: 100%;
+    max-width: none;
   }
   .hero-content img.hero-logo {
     width: 120px;


### PR DESCRIPTION
## Summary
- tweak `.hero-content` media queries so the blue call-to-action bar spans the full width on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849c46e51f88333a9fae0148855560f