### PR TITLE
Fix blue-box width for mobile screens

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -922,11 +922,10 @@ footer {
 @media (max-width: 768px) {
   .blue-box {
     width: 100vw !important;
-    position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
+    margin-left: calc(-50vw + 50%) !important;
+    margin-right: calc(-50vw + 50%) !important;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
     box-sizing: border-box;
   }
 }


### PR DESCRIPTION
## Summary
- ensure `.blue-box` spans the full screen width on mobile

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_684b603f19f08333b2ba9b8d9f1c7e79