### PR TITLE
Fix mobile full-width blue-box

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -927,6 +927,12 @@ footer {
     padding-left: 0 !important;
     padding-right: 0 !important;
     box-sizing: border-box;
+    background-color: #101940;
+  }
+
+  body > .blue-box {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure `.blue-box` stretches edge-to-edge on mobile
- remove side padding when `.blue-box` is a direct body child

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684b628f1a588333b24582674910534a