### PR TITLE
Fix mobile contact section width

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -921,18 +921,13 @@ footer {
 
 @media (max-width: 768px) {
   .blue-box {
-    width: 100vw !important;
-    margin-left: calc(-50vw + 50%) !important;
-    margin-right: calc(-50vw + 50%) !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    box-sizing: border-box;
+    width: calc(100% + 32px); /* 16px left + right */
+    margin-left: -16px;
+    margin-right: -16px;
     background-color: #101940;
-  }
-
-  body > .blue-box {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    padding-left: 0;
+    padding-right: 0;
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove old `blue-box` mobile layout overrides
- add negative margin technique to ensure mobile contact section spans full width

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684b63e2e39c833391fae111df6257a2