### PR TITLE
Fix full-width blue box on mobile

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -921,16 +921,17 @@ footer {
 
 @media (max-width: 768px) {
   .blue-box {
-    width: 100vw;
     position: relative;
-    left: 50%;
-    right: 50%;
-    margin-left: -50vw;
-    margin-right: -50vw;
+    left: 0;
+    right: 0;
+    width: 100vw;
+    max-width: 100vw;
+    margin-left: -16px; /* cancels body padding */
+    margin-right: -16px;
     padding-left: 0;
     padding-right: 0;
-    box-sizing: border-box;
     background-color: #101940;
+    box-sizing: border-box;
   }
 }
 


### PR DESCRIPTION
## Summary
- update the `.blue-box` mobile rule so the blue section expands edge-to-edge

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684b673f566c83338647014bd4ab6359