### PR TITLE
Fix mobile contact section width

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -953,3 +953,25 @@ footer {
     box-sizing: border-box;
   }
 }
+
+@media (max-width: 768px) {
+  .full-width-wrapper {
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    background-color: #101940;
+  }
+
+  .blue-box {
+    background-color: #101940;
+    width: 100%;
+    max-width: 100%;
+    padding-left: 0;
+    padding-right: 0;
+    box-sizing: border-box;
+    color: white;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
   </section>
 
   <!-- Contact Section -->
-  <div class="blue-box-wrapper">
+  <div class="full-width-wrapper">
     <section id="contact" class="blue-box">
     <h2>Book Your Appointment</h2>
     <form id="booking-form">


### PR DESCRIPTION
## Summary
- wrap the contact section in a `full-width-wrapper`
- add responsive rule to break the wrapper out of body padding on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684b6bec58288333b55e0f35e0ea1612