### PR TITLE
Implement mobile centering for blue-box content

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -958,3 +958,32 @@ footer {
     color: #101940;
   }
 }
+
+@media (max-width: 768px) {
+  .blue-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 20px 0;
+    background-color: #101940;
+    color: white;
+  }
+
+  .blue-box button {
+    margin-top: 10px;
+    background-color: #ffd600;
+    color: #101940;
+    padding: 12px 20px;
+    font-size: 16px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+
+  .blue-box button:hover {
+    background-color: #fff;
+    color: #101940;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile media query to center `.blue-box` content and style its button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684b6fdd8f8c833395069aaa10cfd04b