### PR TITLE
Fix mobile navbar layout

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -945,3 +945,43 @@ footer {
   }
 }
 
+@media (max-width: 768px) {
+  .nav-container {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    padding: 0 12px;
+    height: 72px;
+    width: 100%;
+  }
+
+  .logo-title {
+    display: contents;
+  }
+
+  .logo-icon {
+    height: 42px;
+    width: auto;
+  }
+
+  .title-image {
+    display: block;
+    margin: 0 auto;
+    max-height: 48px;
+    width: auto;
+    max-width: 140px;
+    object-fit: contain;
+  }
+
+  .hamburger {
+    font-size: 24px;
+    background: none;
+    border: none;
+    color: white;
+    justify-self: end;
+    padding: 4px;
+    display: block;
+  }
+}
+
+


### PR DESCRIPTION
## Summary
- make mobile nav bar layout use CSS Grid
- keep logo image, title image and hamburger aligned

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684b75a8365483338d493cf3d84858f1