### PR TITLE
Fix mobile navbar logo size

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -1011,9 +1011,14 @@ footer {
     transform: translate(-50%, -50%);
   }
 
-  .logo-left-mobile img,
-  .logo-center-mobile img {
+  .logo-left-mobile img {
     height: 60px; /* Keeps logos large but within nav height */
+    width: auto;
+    object-fit: contain;
+  }
+
+  .logo-center-mobile img {
+    height: 80px; /* Slightly larger logo on mobile */
     width: auto;
     object-fit: contain;
   }


### PR DESCRIPTION
## Summary
- adjust the mobile logo rule so `.logo-center-mobile img` is 80px tall

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684da7cd95288333b3fc1677c03a5a78